### PR TITLE
Add promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configure consulite with any of the following settings
 * `consul` - the base URL to use to connect to consul
 
 
-### getService(name, callback)
+### getService(name [, callback])
 
 Get service address information from cache or from consul. When multiple service
 instances are registered with consul the first instance that hasn't been executed
@@ -35,19 +35,23 @@ the following properties:
   - `address`: the host address where the service is located
   - `port`: the port that the service is exposed on
 
+This function returns a `Promise` if no `callback` is provided.
+
 
 ### getCachedService(name)
 
 Get the next service from the cache if it exists, otherwise return null;
 
 
-### refreshService(name, callback)
+### refreshService(name [, callback])
 
 Makes a request to consul for the given service name and caches the results. Only
 services that are healthy are cached.
 
 * `name`: the service name to fetch from consul.
 * `callback`: function with signature `(err, services)`
+
+This function returns a `Promise` if no `callback` is provided.
 
 
 ## Example Usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Wreck = require('wreck');
+const OrPromise = require('or-promise');
 
 
 // Declare internals
@@ -18,8 +19,10 @@ exports.config = function (config) {
 
 
 exports.getService = function (name, callback) {
+  callback = callback || OrPromise();
   if (internals.hosts[name] && internals.hosts[name].length) {
-    return setImmediate(callback, null, internals.selectNext(internals.hosts[name]));
+    setImmediate(callback, null, internals.selectNext(internals.hosts[name]));
+    return callback.promise;
   }
 
   exports.refreshService(name, (err) => {
@@ -29,6 +32,7 @@ exports.getService = function (name, callback) {
 
     callback(null, internals.selectNext(internals.hosts[name]));
   });
+  return callback.promise;
 };
 
 
@@ -42,6 +46,7 @@ exports.getCachedService = function (name) {
 
 
 exports.refreshService = function (name, callback) {
+  callback = callback || OrPromise();
   let consul = internals.consul;
   if (!consul) {
     const consulHost = process.env.CONSUL_HOST || 'consul';
@@ -75,6 +80,8 @@ exports.refreshService = function (name, callback) {
 
     callback(null, hosts);
   });
+
+  return callback.promise;
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ exports.config = function (config) {
 
 exports.getService = function (name, callback) {
   if (internals.hosts[name] && internals.hosts[name].length) {
-    return callback(null, internals.selectNext(internals.hosts[name]));
+    return setImmediate(callback, null, internals.selectNext(internals.hosts[name]));
   }
 
   exports.refreshService(name, (err) => {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lab": "11.x.x"
   },
   "dependencies": {
-    "wreck": "9.x.x"
+    "wreck": "9.x.x",
+    "or-promise": "1.x.x"
   }
 }


### PR DESCRIPTION
This PR adds support for returning promises from `getService` and `refreshService` when no callback is provided.

In addition, it insures that if a callback is provided to `getService`, it is always executed on a subsequent tick (via `setImmediate`), and never immediately. 
