### PR TITLE
Feature/multiple datacenters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,21 @@ function getArgs (args, template) {
   return result;
 }
 
+function getUri (path, queryObj) {
+  const query = [];
+  Object.getOwnPropertyNames(queryObj).forEach((p) => {
+    if (queryObj[p] === undefined) { return; }
+    if (p === 'nodeMeta') {
+      Object.getOwnPropertyNames(queryObj.nodeMeta).forEach((p) => {
+        query.push(`node-meta=${p}=${queryObj.nodeMeta[p]}`);
+      });
+    } else {
+      query.push(`${p}=${queryObj[p]}`);
+    }
+  });
+  return `${path}?${query.join('&')}`;
+}
+
 
 module.exports = class Consulite {
   constructor (options) {
@@ -61,22 +76,9 @@ module.exports = class Consulite {
       callback: 0
     });
     const callback = cfg.callback || OrPromise();
-    let uri = '/v1/catalog/services';
-    const query = [];
 
-    if (cfg.dc) {
-      query.push('dc=' + cfg.dc);
-    }
-
-    if (cfg.nodeMeta) {
-      Object.getOwnPropertyNames(cfg.nodeMeta).forEach((p) => {
-        query.push(`node-meta=${p}=${cfg.nodeMeta[p]}`);
-      });
-    }
-
-    if (query) {
-      uri += '?' + query.join('&');
-    }
+    const {dc, nodeMeta} = cfg;
+    const uri = getUri('/v1/catalog/services', {dc, nodeMeta});
 
     this._wreck.get(uri, (err, res, payload) => {
       if (err) {
@@ -92,38 +94,17 @@ module.exports = class Consulite {
   }
 
 
-  getServiceStatus (name, callback) {
+  getServiceStatus () {
     const cfg = getArgs(arguments, {
       callback: 1,
       name: 0
     });
-    callback = cfg.callback || OrPromise();
-    name = cfg.name;
 
-    const query = [];
-    let uri = `/v1/health/service/${name}`;
-
-    if (cfg.dc) {
-      query.push('dc=' + cfg.dc);
-    }
-
-    if (cfg.nodeMeta) {
-      Object.getOwnPropertyNames(cfg.nodeMeta).forEach((p) => {
-        query.push(`node-meta=${p}=${cfg.nodeMeta[p]}`);
-      });
-    }
-
-    if (cfg.tag) {
-      query.push('tag=' + cfg.tag);
-    }
-
-    if (cfg.near) {
-      query.push('near=' + cfg.near);
-    }
-
-    if (query) {
-      uri += '?' + query.join('&');
-    }
+    const {name, dc, tag, nodeMeta, near} = cfg;
+    const callback = cfg.callback || OrPromise();
+    const uri = getUri(`/v1/health/service/${name}`, {
+      dc, tag, nodeMeta, near
+    });
 
     this._wreck.get(uri, (err, res, payload) => {
       if (err) {
@@ -157,28 +138,28 @@ module.exports = class Consulite {
   }
 
 
-  getService (name, callback) {
-    callback = callback || OrPromise();
-    this.getServiceHosts(name, (err, hosts) => {
-      if (err) {
-        return callback(err);
-      }
+  getService () {
+    const cfg = getArgs(arguments, {name: 0, callback: 1});
+    const callback = cfg.callback || OrPromise();
+    cfg.callback = (err, hosts) => {
+      if (err) { return callback(err); }
       callback(null, internals.selectNext(hosts));
-    });
-
+    };
+    this.getServiceHosts(cfg);
     return callback.promise;
   }
 
-  getServiceHosts (name, callback) {
-    callback = callback || OrPromise();
-    const hosts = this.getCachedServiceHosts(name);
+  getServiceHosts () {
+    const cfg = getArgs(arguments, {name: 0, callback: 1});
+    const callback = cfg.callback || OrPromise();
+    const hosts = this.getCachedServiceHosts(cfg.name);
 
     if (hosts) {
       setImmediate(callback, null, hosts.slice());
       return callback.promise;
     }
 
-    this.refreshService(name, (err, hosts) => {
+    this.refreshService(cfg.name, (err, hosts) => {
       if (err) {
         return callback(err);
       }
@@ -209,16 +190,17 @@ module.exports = class Consulite {
   }
 
 
-  refreshService (name, callback) {
-    callback = callback || OrPromise();
+  refreshService () {
+    const cfg = getArgs(arguments, {name: 0, callback: 1});
+    const callback = cfg.callback || OrPromise();
 
-    this._wreck.get(`/v1/health/service/${name}?passing&near=agent`, (err, res, payload) => {
+    this._wreck.get(`/v1/health/service/${cfg.name}?passing&near=agent`, (err, res, payload) => {
       if (err) {
         return callback(err);
       }
 
       if (!payload || !payload.length) {
-        return callback(new Error(`Service ${name} couldn't be found`));
+        return callback(new Error(`Service ${cfg.name} couldn't be found`));
       }
 
       const hosts = payload.map((host) => {
@@ -228,7 +210,7 @@ module.exports = class Consulite {
         };
       });
 
-      this._hosts[name] = hosts;
+      this._hosts[cfg.name] = hosts;
 
       callback(null, hosts);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,31 @@ const OrPromise = require('or-promise');
 
 const internals = {};
 
+function isSingleObject (args) {
+  if (args.length !== 1) {
+    return false;
+  }
+
+  const prototype = Object.prototype.toString.call(args[0]);
+  return prototype === '[object Object]';
+}
+
+function getArgs (args, template) {
+  if (isSingleObject(args)) {
+    return args[0];
+  }
+
+  const result = {};
+  Object.getOwnPropertyNames(template).forEach((p) => {
+    const idx = template[p];
+    if (args.length >= idx) {
+      result[p] = args[idx];
+    }
+  });
+
+  return result;
+}
+
 
 module.exports = class Consulite {
   constructor (options) {
@@ -31,10 +56,29 @@ module.exports = class Consulite {
   }
 
 
-  getServiceNames (callback) {
-    callback = callback || OrPromise();
+  getServiceNames () {
+    const cfg = getArgs(arguments, {
+      callback: 0
+    });
+    const callback = cfg.callback || OrPromise();
+    let uri = '/v1/catalog/services';
+    const query = [];
 
-    this._wreck.get('/v1/catalog/services', (err, res, payload) => {
+    if (cfg.dc) {
+      query.push('dc=' + cfg.dc);
+    }
+
+    if (cfg.nodeMeta) {
+      Object.getOwnPropertyNames(cfg.nodeMeta).forEach((p) => {
+        query.push(`node-meta=${p}=${cfg.nodeMeta[p]}`);
+      });
+    }
+
+    if (query) {
+      uri += '?' + query.join('&');
+    }
+
+    this._wreck.get(uri, (err, res, payload) => {
       if (err) {
         return callback(err);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,13 +159,15 @@ module.exports = class Consulite {
       return callback.promise;
     }
 
-    this.refreshService(cfg.name, (err, hosts) => {
+    cfg.callback = (err, hosts) => {
       if (err) {
         return callback(err);
       }
 
       callback(null, hosts.slice());
-    });
+    };
+
+    this.refreshService(cfg);
     return callback.promise;
   }
 
@@ -193,8 +195,12 @@ module.exports = class Consulite {
   refreshService () {
     const cfg = getArgs(arguments, {name: 0, callback: 1});
     const callback = cfg.callback || OrPromise();
+    const {dc, tag, nodeMeta, near} = cfg;
+    const path = `/v1/health/service/${cfg.name}`;
 
-    this._wreck.get(`/v1/health/service/${cfg.name}?passing&near=agent`, (err, res, payload) => {
+    const uri = getUri(path, {dc, tag, nodeMeta, near: (near || 'agent'), passing: 1});
+
+    this._wreck.get(uri, (err, res, payload) => {
       if (err) {
         return callback(err);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,7 @@ module.exports = class Consulite {
 
       const hosts = payload.map((host) => {
         return {
-          address: host.Service.Address,
+          address: host.Service.Address || host.Node.Address,
           port: host.Service.Port
         };
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,9 +93,39 @@ module.exports = class Consulite {
 
 
   getServiceStatus (name, callback) {
-    callback = callback || OrPromise();
+    const cfg = getArgs(arguments, {
+      callback: 1,
+      name: 0
+    });
+    callback = cfg.callback || OrPromise();
+    name = cfg.name;
 
-    this._wreck.get(`/v1/health/service/${name}`, (err, res, payload) => {
+    const query = [];
+    let uri = `/v1/health/service/${name}`;
+
+    if (cfg.dc) {
+      query.push('dc=' + cfg.dc);
+    }
+
+    if (cfg.nodeMeta) {
+      Object.getOwnPropertyNames(cfg.nodeMeta).forEach((p) => {
+        query.push(`node-meta=${p}=${cfg.nodeMeta[p]}`);
+      });
+    }
+
+    if (cfg.tag) {
+      query.push('tag=' + cfg.tag);
+    }
+
+    if (cfg.near) {
+      query.push('near=' + cfg.near);
+    }
+
+    if (query) {
+      uri += '?' + query.join('&');
+    }
+
+    this._wreck.get(uri, (err, res, payload) => {
       if (err) {
         return callback(err);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consulite",
-  "version": "2.0.0",
+  "version": "2.1.0-beta",
   "description": "Tiny consul Node.js module for client discovery",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -282,6 +282,44 @@ describe('getServiceStatus()', () => {
       });
     });
   });
+
+  it('supports nodeMeta, tag, near, and datacenter', (done) => {
+    const server = Http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('[]');
+    });
+
+    server.on('error', (err) => {
+      expect(err).to.not.exist();
+    });
+
+    server.listen(0, () => {
+      wreck.once('request', (uri, options) => {
+        expect(uri.path).to.contain('redis');
+        expect(uri.query).to.contain('node-meta=size=big');
+        expect(uri.query).to.contain('tag=master');
+        expect(uri.query).to.contain('dc=eu-west-1');
+        expect(uri.query).to.contain('near=somenode');
+
+        uri.hostname = 'localhost';
+        uri.port = server.address().port;
+      });
+
+      const consulite = new Consulite({ consul: `http://localhost:${server.address().port}` });
+      consulite.getServiceStatus({
+        name: 'redis',
+        dc: 'eu-west-1',
+        tag: 'master',
+        near: 'somenode',
+        nodeMeta: {
+          size: 'big'
+        }
+      }).then((nodes) => {
+        expect(nodes.length).to.equal(0);
+        done();
+      });
+    });
+  });
 });
 
 describe('getService()', () => {


### PR DESCRIPTION
This PR is offered speculatively in case you want it.

For a system I'm currently working on, I needed to be able to query services from a separate datacenter. I like the design of consulite, but was disappointed that it wouldn't support my use-case.

This PR makes it possible to call each of `getServiceNames`, `getServiceStatus`, `getServiceHosts`, `refreshService`, `getService` with a parameters object. The parameters object must be the only argument passed to the method. Using the parameters object allows a user to specify additional parameters including `dc` for datacenter, but also `tag`, `node-meta` etc.

Existing tests continue to pass so this change is, I very much hope, backward compatible though the code is somewhat ugly.